### PR TITLE
Revamp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,8 +43,10 @@ RUN apk add --update --no-cache --virtual .build-deps \
     && cd /usr/lstu \
     && carton install \
     && apk del .build-deps \
-    && rm -rf /var/cache/apk/* /root/.cpan* /usr/lstu/local/cache/* /usr/lstu/utilities
-    
+    && rm -rf /var/cache/apk/* /root/.cpan* /usr/lstu/local/cache/*
+
+VOLUME /usr/lstu/data
+
 EXPOSE 8282
 
 COPY startup /usr/local/bin/startup

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM alpine:3.8
 
+ARG LSTU_VERSION=0.20-1
+
 ENV GID=991 \
     UID=991 \
     SECRET=f6056062888a9a6aff1cc89dd3397853 \
@@ -37,7 +39,7 @@ RUN apk add --update --no-cache --virtual .build-deps \
                 libpng \
     && echo | cpan \
     && cpan install Carton \
-    && git clone https://git.framasoft.org/luc/lstu.git /usr/lstu \
+    && git clone -b ${LSTU_VERSION} https://framagit.org/luc/lstu.git /usr/lstu \
     && cd /usr/lstu \
     && carton install \
     && apk del .build-deps \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM xataz/alpine:3.7
+FROM alpine:3.8
 
 ENV GID=991 \
     UID=991 \
@@ -13,7 +13,8 @@ LABEL description="lstu based on alpine" \
       build_ver="201805160600" \
       commit="7a0e602af4410af68f24b75201f701f22208bb0d"
 
-RUN BUILD_DEPS="build-base \
+RUN apk add --update --no-cache --virtual .build-deps \
+                build-base \
                 libressl-dev \
                 ca-certificates \
                 git \
@@ -23,8 +24,8 @@ RUN BUILD_DEPS="build-base \
                 wget \
                 postgresql-dev \
                 libpng-dev \
-                mariadb-dev" \
-    && apk add -U ${BUILD_DEPS} \
+                mariadb-dev \
+    && apk add --update --no-cache \
                 libressl \
                 perl \
                 libidn \
@@ -32,14 +33,14 @@ RUN BUILD_DEPS="build-base \
                 su-exec \
                 perl-net-ssleay \
                 postgresql-libs \
-                mariadb-client-libs \
+                mariadb-client \
                 libpng \
     && echo | cpan \
     && cpan install Carton \
     && git clone https://git.framasoft.org/luc/lstu.git /usr/lstu \
     && cd /usr/lstu \
     && carton install \
-    && apk del ${BUILD_DEPS} \
+    && apk del .build-deps \
     && rm -rf /var/cache/apk/* /root/.cpan* /usr/lstu/local/cache/* /usr/lstu/utilities
     
 EXPOSE 8282

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN apk add --update --no-cache --virtual .build-deps \
                 su-exec \
                 perl-net-ssleay \
                 postgresql-libs \
-                mariadb-client \
+                perl-dbd-mysql \
                 libpng \
     && echo | cpan \
     && cpan install Carton \
@@ -43,7 +43,10 @@ RUN apk add --update --no-cache --virtual .build-deps \
     && cd /usr/lstu \
     && carton install \
     && apk del .build-deps \
-    && rm -rf /var/cache/apk/* /root/.cpan* /usr/lstu/local/cache/*
+    && rm -rf /var/cache/apk/* /root/.cpan* /usr/lstu/local/cache/* \
+    && rm /usr/lstu/local/lib/perl5/x86_64-linux-thread-multi/auto/DBD/mysql/mysql.so
+# This last one is a very weird fix for the following error:
+# Can't load application from file "/usr/lstu/script/lstu": Can't load '/usr/lstu/local/lib/perl5/x86_64-linux-thread-multi/auto/DBD/mysql/mysql.so' for module DBD::mysql: Error relocating /usr/lstu/local/lib/perl5/x86_64-linux-thread-multi/auto/DBD/mysql/mysql.so: net_buffer_length: symbol not found at /usr/lib/perl5/core_perl/DynaLoader.pm line 193.
 
 VOLUME /usr/lstu/data
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![](https://git.framasoft.org/uploads/project/avatar/5/lstu.png)
+![](https://framagit.org/luc/lstu/raw/master/themes/default/public/img/lstu128.png)
 
 [![Build Status](https://drone.xataz.net/api/badges/xataz/docker-lstu/status.svg)](https://drone.xataz.net/xataz/docker-lstu)
 [![](https://images.microbadger.com/badges/image/xataz/lstu.svg)](https://microbadger.com/images/xataz/lstu "Get your own image badge on microbadger.com")
@@ -8,10 +8,10 @@
 > If you don't trust, you can build yourself.
 
 ## Tag available
-* latest [(lstu/Dockerfile)](https://github.com/xataz/dockerfiles/blob/master/lstu/Dockerfile)
+* latest [(lstu/Dockerfile)](https://github.com/xataz/docker-lstu/blob/master/Dockerfile)
 
 ## Description
-What is [lstu](https://git.framasoft.org/luc/lstu) ?
+What is [lstu](https://framagit.org/luc/lstu) ?
 
 It means Let's Shorten That Url.
 
@@ -20,7 +20,7 @@ It means Let's Shorten That Url.
 ## BUILD IMAGE
 
 ```shell
-docker build -t xataz/lstu github.com/xataz/dockerfiles.git#master:lstu
+docker build -t xataz/lstu github.com/xataz/docker-lstu.git#master
 ```
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ docker build -t xataz/lstu github.com/xataz/docker-lstu.git#master
 Tip : you can use the following command to generate SECRET. `date +%s | md5sum | head -c 32`
 
 ### Volumes
+* /usr/lstu/lstu.conf : lstu's configuration file is here
 * /usr/lstu/data/ : lstu's database is here
 
 ### Ports

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ What is [lstu](https://framagit.org/luc/lstu) ?
 
 It means Let's Shorten That Url.
 
-**This image not contains root process**
+**This image does not contain root processes**
 
 ## BUILD IMAGE
 
@@ -25,11 +25,11 @@ docker build -t xataz/lstu github.com/xataz/docker-lstu.git#master
 
 ## Configuration
 ### Environments
-* UID : Choose uid for launch lstu (default : 991)
-* GID : Choose gid for launch lstu (default : 991)
+* UID : choose uid for launching lstu (default : 991)
+* GID : choose gid for launching lstu (default : 991)
 * WEBROOT : webroot of lstu (default : /)
 * SECRET : random string used to encrypt cookies (default : f6056062888a9a6aff1cc89dd3397853)
-* ADMINPWD : Password for access to statistique page. (default : s3cr3T)
+* ADMINPWD : password to access the statistics page. (default : s3cr3T)
 * CONTACT : lstu contact (default : contact@domain.tld)
 
 Tip : you can use the following command to generate SECRET. `date +%s | md5sum | head -c 32`
@@ -50,16 +50,16 @@ URI access : http://XX.XX.XX.XX:8282
 ### Advanced launch
 ```shell
 docker run -d -p 8181:8282 \
-	-v /docker/config/lstu:/usr/lstu/data \
-	-e UID=1001 \
-	-e GID=1001 \
+    -v /docker/config/lstu:/usr/lstu/data \
+    -e UID=1001 \
+    -e GID=1001 \
     -e WEBROOT=/lstu \
     -e SECRET=$(date +%s | md5sum | head -c 32) \
     -e CONTACT=contact@mydomain.com \
     -e ADMINPWD="mypassword" \
-	xataz/lstu
+    xataz/lstu
 ```
 URI access : http://XX.XX.XX.XX:8181/lstu
 
 ## Contributing
-Any contributions, are very welcome !
+Any contributions are very welcome !

--- a/startup
+++ b/startup
@@ -2,13 +2,16 @@
 
 addgroup -g ${GID} lstu && adduser -H -s /bin/sh -D -G lstu -u ${UID} lstu
 
-mkdir -p /usr/lstu/data
-chown -R lstu:lstu /usr/lstu
+cd /usr/lstu
+mkdir -p data
+chown -R lstu:lstu .
 
-sed -i -e 's|<secret>|'${SECRET}'|' \
+# Outputting directly to lstu.conf using "sed -i" when mounted with docker fails.
+echo "$(sed \
+        -e 's|<secret>|'${SECRET}'|' \
         -e 's|<contact>|'${CONTACT}'|' \
         -e 's|<adminpwd>|'${ADMINPWD}'|' \
-        -e 's|<webroot>|'${WEBROOT}'|' /usr/lstu/lstu.conf
+        -e 's|<webroot>|'${WEBROOT}'|' lstu.conf
+)" > lstu.conf
 
-cd /usr/lstu
 exec su-exec lstu:lstu /sbin/tini -- /usr/local/bin/carton exec hypnotoad -f /usr/lstu/script/lstu


### PR DESCRIPTION
- Use latest Alpine base image (v3.8)
- Use latest framagit.org URL (instead of git.framasoft.org)
- Add version arg and set to latest one available
- Make use of [virtual packages](https://github.com/gliderlabs/docker-alpine/blob/master/docs/usage.md#virtual-packages) for removal of build dependencies.
- Make sure volumes are defined correctly
- Keep utilities folder, as required migration scripts live there!
- Update readme, correct grammar and fix broken links

The last commit is a very peculiar fix to use MySQL. Not sure how else to get MySQL to work correctly, as the container just crashes with the following error:
```
Can't load application from file "/usr/lstu/script/lstu": Can't load '/usr/lstu/local/lib/perl5/x86_64-linux-thread-multi/auto/DBD/mysql/mysql.so' for module DBD::mysql: Error relocating /usr/lstu/local/lib/perl5/x86_64-linux-thread-multi/auto/DBD/mysql/mysql.so: net_buffer_length: symbol not found at /usr/lib/perl5/core_perl/DynaLoader.pm line 193.
 at /usr/lstu/local/lib/perl5/Mojo/mysql/Database.pm line 5.
Compilation failed in require at /usr/lstu/local/lib/perl5/Mojo/mysql/Database.pm line 5.
BEGIN failed--compilation aborted at /usr/lstu/local/lib/perl5/Mojo/mysql/Database.pm line 5.
Compilation failed in require at /usr/lstu/local/lib/perl5/Mojo/mysql.pm line 7.
BEGIN failed--compilation aborted at /usr/lstu/local/lib/perl5/Mojo/mysql.pm line 7.
Compilation failed in require at /usr/lstu/script/../lib/Lstu/Plugin/Helpers.pm line 44.
Compilation failed in require at (eval 79) line 1.
```
It seems like this lib isn't required, as deleting it fixes the error and the app runs :confused:

@xataz Let me know if you want anything changed, just share your thoughts :+1: